### PR TITLE
The reset has taken out ol li type styling

### DIFF
--- a/app/css/general.styl
+++ b/app/css/general.styl
@@ -65,7 +65,7 @@ ul
 	-webkit-margin-end: 0px
 	-webkit-padding-start: 40px
 
-ul
+#wiki ul
 	list-style-type: decimal
 	li
 		margin-left: 35px;


### PR DESCRIPTION
See http://webpack.github.io/docs/loaders.html#loader-order. There should be an ordered list there.
