### PR TITLE
Fixed incorrect link

### DIFF
--- a/layouts/landing.html
+++ b/layouts/landing.html
@@ -89,7 +89,7 @@
 						<div class="col-md-6">
 							<div class="feature">
 								<h4>Development Tools</h4>
-								<p>webpack supports SourceUrls and <strong>SourceMaps</strong>. Debugging will be nice. It can watch your files and comes with a <a href="webpack-dev-middleware.html">development middleware</a> and a <a href="webpack-dev-middleware.html">development server</a> for <strong>automatic reloading</strong>.</p>
+								<p>webpack supports SourceUrls and <strong>SourceMaps</strong>. Debugging will be nice. It can watch your files and comes with a <a href="webpack-dev-middleware.html">development middleware</a> and a <a href="webpack-dev-server.html">development server</a> for <strong>automatic reloading</strong>.</p>
 							</div>
 						</div>
 						<div class="col-md-6">


### PR DESCRIPTION
Fixed link to `webpack-dev-server.html`, was pointing (incorrectly) to `webpack-dev-middleware.html`.
