### PR TITLE
Fixed image width on Firefox

### DIFF
--- a/app/css/general.styl
+++ b/app/css/general.styl
@@ -219,9 +219,13 @@ p > img
 			padding-right: 15px
 		.col-md-3
 			flex: 3
+			min-width: 0
 		.col-md-6
 			flex: 6
+			min-width: 0
 		.col-md-9
 			flex: 9
+			min-width: 0
 		.col-md-12
 			flex: 12
+			min-width: 0


### PR DESCRIPTION
To fix this bug submitted on webcompat https://github.com/webcompat/web-bugs/issues/754

There are troubles of image sizes on Firefox because of `flex`

As @dholbert proposes, adding `min-width:0` fixed the bug.

![webpack](https://cloud.githubusercontent.com/assets/1997108/6492346/7684b3e0-c2b3-11e4-87f5-43e3bc859577.png)
