### PR TITLE
Check for modifier key before pushState

### DIFF
--- a/app/bindToIntraLinks.js
+++ b/app/bindToIntraLinks.js
@@ -5,9 +5,14 @@ var LRU = require("lru-cache");
 
 var INTRA_LINK = /^([a-z0-9\-\.]+)\.html$/i;
 
+
+function hasModifier(event) {
+	return event.metaKey || event.shiftKey || event.altKey || event.ctrlKey;
+}
+
 function bindIntraLinks() {
 	document.body.addEventListener("click", function(event) {
-		if(event.target.tagName === "A" && INTRA_LINK.test(event.target.getAttribute("href"))) {
+		if(event.target.tagName === "A" && !hasModifier(event) && INTRA_LINK.test(event.target.getAttribute("href"))) {
 			var href = event.target.getAttribute("href");
 			INTRA_LINK.lastIndex = 0;
 			var wiki = INTRA_LINK.exec(href)[1];


### PR DESCRIPTION
Allows "command+click" to open in a new tab,  "shift+click" to open in a new window, and whatever other thing modifier keys do.