### PR TITLE
needs double quotes to run with no errors

### DIFF
--- a/tutorials/getting-started/1.5 binding-loaders/README.md
+++ b/tutorials/getting-started/1.5 binding-loaders/README.md
@@ -9,7 +9,7 @@ $$$ files
 Run the compilation with:
 
 ``` text
-webpack ./entry.js bundle.js --module-bind 'css=style!css'
+webpack ./entry.js bundle.js --module-bind "css=style!css"
 ```
 
 You should see the same result:


### PR DESCRIPTION
I Am following the tutoria,l and had to google for help. When running command with single quotes i get an error:

Error in ./style.css
Module parse failed ....
You may need an appropriate loader to handle this file type.
...

May be related to webpack issue #1130 https://github.com/webpack/webpack/issues/1130