### PR TITLE
Use single quotes in binding loaders command line example with exclamation point

### DIFF
--- a/tutorials/getting-started/1.5 binding-loaders/README.md
+++ b/tutorials/getting-started/1.5 binding-loaders/README.md
@@ -9,7 +9,7 @@ $$$ files
 Run the compilation with:
 
 ``` text
-webpack ./entry.js bundle.js --module-bind "css=style!css"
+webpack ./entry.js bundle.js --module-bind 'css=style!css'
 ```
 
 You should see the same result:


### PR DESCRIPTION
Using double quotes around a string that has an exclamation point will cause problems with bash. This just changes it to have single quotes instead.

Changes this to use single quotes:

    webpack ./entry.js bundle.js --module-bind "css=style!css"