### PR TITLE
Single Quotations Needed

### DIFF
--- a/tutorials/getting-started/1.5 binding-loaders/README.md
+++ b/tutorials/getting-started/1.5 binding-loaders/README.md
@@ -9,7 +9,7 @@ $$$ files
 Run the compilation with:
 
 ``` text
-webpack ./entry.js bundle.js --module-bind "css=style!css"
+webpack ./entry.js bundle.js --module-bind 'css=style!css'
 ```
 
 You should see the same result:


### PR DESCRIPTION
Single quotations were needed in order to use `--module-bind`. Other,  a `-bash: !css: event not found` error is returned. 

(This was tested on a debian-jessie64 Vagrant box).