### PR TITLE
Fix list margin and padding on Firefox

### DIFF
--- a/app/css/general.styl
+++ b/app/css/general.styl
@@ -75,10 +75,15 @@ ul
 	display: block
 	list-style-type: disc
 	-webkit-margin-before: 1em
+	-moz-margin-before: 1em
 	-webkit-margin-after: 1em
+	-moz-margin-after: 1em
 	-webkit-margin-start: 0px
+	-moz-margin-start: 0px
 	-webkit-margin-end: 0px
+	-moz-margin-end: 0px
 	-webkit-padding-start: 40px
+	-moz-padding-start: 40px
 
 ol
 	list-style-type: decimal


### PR DESCRIPTION
Indentation is missing on unordered lists in Firefox, making it difficult to read. Adding the `-moz`-prefixed CSS properties fixes the problem.
