### PR TITLE
Add autocomplete search via DocSearch project

### DIFF
--- a/app/css/sidebar.styl
+++ b/app/css/sidebar.styl
@@ -32,3 +32,6 @@
 		color: #333
 		display: block
 		border-right: 4px solid #ddd
+
+.searchbox
+	margin: 20px 0 15px

--- a/app/doc.js
+++ b/app/doc.js
@@ -1,6 +1,7 @@
 require("./css/doc.styl");
 require("./googleAnalytics");
 require("./disqus");
+require("./docsearch");
 
 require("./onContentLoaded")(function(event) {
 	require("./bindToIntraLinks");

--- a/app/docsearch.js
+++ b/app/docsearch.js
@@ -1,0 +1,9 @@
+require("./onContentLoaded")(function(event) {
+  var search = docsearch({
+    inputSelector: '#docsearch',
+    apiKey: '93950c6eda05068a6f0649e4a7f7546e',
+    indexName: 'webpack',
+    debug: false,
+    enhancedSearchInput: true
+  });
+})

--- a/app/landing.js
+++ b/app/landing.js
@@ -1,2 +1,3 @@
 require("./css/landing.styl");
 require("./googleAnalytics");
+require("./docsearch");

--- a/layouts/doc.html
+++ b/layouts/doc.html
@@ -7,10 +7,12 @@
 		<meta name="description" content="">
 		<meta name="author" content="">
 		<link rel="icon" type="image/png" href="/assets/favicon.png" />
+		<link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 		<link rel="stylesheet" href="css/doc.css" />
 		<title>{{title}}</title>
 	</head>
 	<body>
+		<script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" charset="utf-8" async></script>
 		<script src="js/doc.js" charset="utf-8" async></script>
 		<div class="container">
 			<div class="row">
@@ -19,6 +21,7 @@
 					{{include logo}}
 
 					<div class="sidebar">
+						<input id="docsearch" type="text" />
 						<ul><li><a href=".">Home</a></li></ul>
 						{{wiki contents}}
 					</div>

--- a/layouts/doc.html
+++ b/layouts/doc.html
@@ -7,12 +7,12 @@
 		<meta name="description" content="">
 		<meta name="author" content="">
 		<link rel="icon" type="image/png" href="/assets/favicon.png" />
-		<link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2.1.8/docsearch.min.css" integrity="sha384-/h/CVRynn/dNPld+6a4vrwfa+2rmLNF4BIustqdtI2P8kqtFvUOsgA+TXqp+6F04" crossorigin="anonymous">
 		<link rel="stylesheet" href="css/doc.css" />
 		<title>{{title}}</title>
 	</head>
 	<body>
-		<script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" charset="utf-8" async></script>
+		<script src="https://cdn.jsdelivr.net/docsearch.js/2.1.8/docsearch.min.js" integrity="sha384-u5+p4sI6IAzw0829Aqivzf5sJed6yKCHDofUkWCK5Zs6w/DQr9JleVL3lrVLgufR" crossorigin="anonymous" async></script>
 		<script src="js/doc.js" charset="utf-8" async></script>
 		<div class="container">
 			<div class="row">

--- a/layouts/landing.html
+++ b/layouts/landing.html
@@ -7,10 +7,12 @@
 		<meta name="description" content="">
 		<meta name="author" content="">
 		<link rel="icon" type="image/png" href="/assets/favicon.png" />
+		<link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 		<link rel="stylesheet" href="css/landing.css" />
 		<title>webpack</title>
 	</head>
 	<body>
+		<script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" charset="utf-8" async></script>
 		<script src="js/landing.js" charset="utf-8" async></script>
 		<div class="container">
 			<div class="row">
@@ -19,6 +21,7 @@
 					{{include logo}}
 
 					<div class="sidebar">
+						<input id="docsearch" type="text" />
 						<ul><li><a href="." class="active">Home</a></li></ul>
 						{{wiki contents}}
 					</div>

--- a/layouts/landing.html
+++ b/layouts/landing.html
@@ -7,12 +7,12 @@
 		<meta name="description" content="">
 		<meta name="author" content="">
 		<link rel="icon" type="image/png" href="/assets/favicon.png" />
-		<link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2.1.8/docsearch.min.css" integrity="sha384-/h/CVRynn/dNPld+6a4vrwfa+2rmLNF4BIustqdtI2P8kqtFvUOsgA+TXqp+6F04" crossorigin="anonymous">
 		<link rel="stylesheet" href="css/landing.css" />
 		<title>webpack</title>
 	</head>
 	<body>
-		<script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" charset="utf-8" async></script>
+		<script src="https://cdn.jsdelivr.net/docsearch.js/2.1.8/docsearch.min.js" integrity="sha384-u5+p4sI6IAzw0829Aqivzf5sJed6yKCHDofUkWCK5Zs6w/DQr9JleVL3lrVLgufR" crossorigin="anonymous" async></script>
 		<script src="js/landing.js" charset="utf-8" async></script>
 		<div class="container">
 			<div class="row">


### PR DESCRIPTION
This PR adds search to the webpack documentation based on the [DocSearch](https://community.algolia.com/docsearch/) project. The search index is updated by Algolia automatically every 24 hours. The configuration for the indexing process lives in [docsearch-configs/configs/webpack.json](https://github.com/algolia/docsearch-configs/blob/master/configs/webpack.json).

Here's a screenshot of the search box and the results overlay.

![Searching webpack docs](https://www.dropbox.com/s/ydwmwx5nlggxkn6/Screenshot%202016-09-21%2014.38.35.png?raw=1 "Searching webpack docs")